### PR TITLE
[BlueJeans] Update recipes for sparkle feed for version 2

### DIFF
--- a/Bluejeans/BluejeansApp.download.recipe
+++ b/Bluejeans/BluejeansApp.download.recipe
@@ -3,43 +3,64 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download recipe for Bluejeans app.</string>
+    <string>Downloads the latest version of BlueJeans.</string>
     <key>Identifier</key>
     <string>com.github.gregneagle.download.bluejeansapp</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>BluejeansApp</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>https://swdl.bluejeans.com/desktop-app/mac/ga.appcast.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.0.0</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>BluejeansAppURLProvider</string>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
-        <dict>   
-            <key>Processor</key>   
-            <string>CodeSignatureVerifier</string>   
-            <key>Arguments</key>   
-            <dict>   
-                <key>input_path</key>   
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
                 <string>%pathname%</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: Blue Jeans Network, Inc. (HE4P42JBGN)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/BlueJeans.app</string>
+                <key>requirement</key>
+                <string>identifier "com.bluejeansnet.Blue" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HE4P42JBGN</string>
             </dict>
         </dict>
     </array>

--- a/Bluejeans/BluejeansApp.install.recipe
+++ b/Bluejeans/BluejeansApp.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest Bluejeans app and installs it.</string>
+    <string>Installs the latest version of BlueJeans.</string>
     <key>Identifier</key>
     <string>com.github.gregneagle.install.bluejeansapp</string>
     <key>Input</key>
@@ -12,18 +12,38 @@
         <string>BluejeansApp</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.gregneagle.pkg.bluejeansapp</string>
+    <string>com.github.gregneagle.download.bluejeansapp</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>Installer</string>
+            <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%filename%</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>InstallFromDMG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%dmg_path%</string>
+                <key>items_to_copy</key>
+                <array>
+                    <dict>
+                        <key>destination_path</key>
+                        <string>/Applications</string>
+                        <key>source_item</key>
+                        <string>BlueJeans.app</string>
+                    </dict>
+                </array>
             </dict>
         </dict>
     </array>

--- a/Bluejeans/BluejeansApp.munki.recipe
+++ b/Bluejeans/BluejeansApp.munki.recipe
@@ -3,102 +3,62 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest Bluejeans app pkg and imports into Munki.</string>
+    <string>Downloads the latest version of BlueJeans and imports it into Munki.</string>
     <key>Identifier</key>
     <string>com.github.gregneagle.munki.bluejeansapp</string>
     <key>Input</key>
     <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
         <key>NAME</key>
         <string>BluejeansApp</string>
-        <key>MUNKI_CATEGORY</key>
-        <string>Communications</string>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps</string>
         <key>pkginfo</key>
         <dict>
-            <key>blocking_applications</key>
-            <array>
-                <string>Blue Jeans.app/Contents/Frameworks/BlueJeans Media.app</string>
-            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
             </array>
             <key>category</key>
-            <string>%MUNKI_CATEGORY%</string>
+            <string>Communications</string>
             <key>description</key>
             <string>Bluejeans video conferencing application</string>
             <key>developer</key>
-            <string>Bluejeans</string>
+            <string>BlueJeans</string>
             <key>display_name</key>
-            <string>Bluejeans Application</string>
+            <string>BlueJeans Application</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
         </dict>
     </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.gregneagle.pkg.bluejeansapp</string>
+    <string>com.github.gregneagle.download.bluejeansapp</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>PkgRootCreator</string>
+            <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0755</string>
-                </dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
+            <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/BlueJeansSetup.pkg/Payload</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Applications/</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/Blue Jeans.app</string>
-                </array>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/payload/</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>additional_makepkginfo_options</key>
-                <array>
-                    <string>--pkgvers</string>
-                    <string>%version%</string>
-                </array>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%filename%</string>
+                <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
         </dict>
     </array>
 </dict>

--- a/Bluejeans/BluejeansApp.pkg.recipe
+++ b/Bluejeans/BluejeansApp.pkg.recipe
@@ -3,71 +3,29 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Package recipe for Bluejeans app. This recipe replaces a postinstall script 
-with a neutered version; the original attempts to change the ownership of the installed
-application to the user who performed the install.</string>
+    <string>Downloads the latest version of BlueJeans and creates a package.</string>
     <key>Identifier</key>
     <string>com.github.gregneagle.pkg.bluejeansapp</string>
     <key>Input</key>
     <dict>
+        <key>BUNDLE_ID</key>
+        <string>com.bluejeansnet.Blue</string>
         <key>NAME</key>
         <string>BluejeansApp</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>com.github.gregneagle.download.bluejeansapp</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
+            <string>AppPkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>purge_destination</key>
-                <true/>
-                <key>flat_pkg_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/unpack/BlueJeansSetup.pkg/Scripts/postinstall.sh</string>
-                </array>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>file_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/BlueJeansSetup.pkg/Scripts/postinstall.sh</string>
-                <key>file_mode</key>
-                <string>0755</string>
-                <key>file_content</key>
-                <string>#!/bin/sh
-# Placeholder script--just exit with success
-exit 0
-                </string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/%filename%</string>
-                <key>source_flatpkg_dir</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>app_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/BlueJeans.app</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Updated the recipes for version 2 of the BlueJeans app. Switched it to using the sparkle feed. There's no need for the url provider any more but I left it in the directory.

Sample run:
```
$ autopkg run BluejeansApp.munki.recipe -v
Processing BluejeansApp.munki.recipe...
WARNING: BluejeansApp.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.7.1.137
SparkleUpdateInfoProvider: Found URL https://swdl.bluejeans.com/desktop-app/mac/2.7.1/2.7.1.137/blue.zip
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 17 Aug 2018 18:44:17 GMT
URLDownloader: Storing new ETag header: "f6dc1ce96106bc5ca5858208aabd0c68"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/downloads/BluejeansApp-2.7.1.137.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename BluejeansApp-2.7.1.137.zip
Unarchiver: Unarchived /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/downloads/BluejeansApp-2.7.1.137.zip to /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/BluejeansApp
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/BluejeansApp/BlueJeans.app: valid on disk
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/BluejeansApp/BlueJeans.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/BluejeansApp/BlueJeans.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/BluejeansApp at /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/BluejeansApp.dmg
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/BluejeansApp/BluejeansApp-2.7.1.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/BluejeansApp/BluejeansApp-2.7.1.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/receipts/BluejeansApp.munki-receipt-20180910-112716.plist

The following new items were imported into Munki:
    Name          Version  Catalogs  Pkginfo Path                                Pkg Repo Path                             
    ----          -------  --------  ------------                                -------------                             
    BluejeansApp  2.7.1    testing   apps/BluejeansApp/BluejeansApp-2.7.1.plist  apps/BluejeansApp/BluejeansApp-2.7.1.dmg  

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/cwhits/Library/AutoPkg/Cache/com.github.gregneagle.munki.bluejeansapp/downloads/BluejeansApp-2.7.1.137.zip  
```
