### PR TITLE
Use core DeprecationWarning processor instead of shared processor

### DIFF
--- a/Bluejeans/BluejeansApp.install.recipe
+++ b/Bluejeans/BluejeansApp.install.recipe
@@ -12,14 +12,14 @@
         <string>BluejeansApp</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.moofit-recipes.download.bluejeans</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Bluejeans/BluejeansApp.munki.recipe
+++ b/Bluejeans/BluejeansApp.munki.recipe
@@ -6,6 +6,8 @@
     <string>Downloads latest Bluejeans app pkg and imports into Munki.</string>
     <key>Identifier</key>
     <string>com.github.gregneagle.munki.bluejeansapp</string>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -52,7 +54,7 @@ fi
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/Mozilla/FirefoxAutoconfig.pkg.recipe
+++ b/Mozilla/FirefoxAutoconfig.pkg.recipe
@@ -44,14 +44,14 @@ so you may need to verify that any particular combination is offered.</string>
         <string>org.mozilla.firefox.pkg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.firefox-rc-en_US</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/SuspiciousPackageXip/SuspiciousPackageXip.download.recipe
+++ b/SuspiciousPackageXip/SuspiciousPackageXip.download.recipe
@@ -14,24 +14,24 @@ Requires a post-0.5.2 version of CodeSignatureVerifier.</string>
         <string>SuspiciousPackage</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.5.3</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
                 <string>This recipe is now non-functional. Please remove it from your list of recipes.</string>
             </dict>
         </dict>
-        <dict>   
-            <key>Processor</key>   
-            <string>StopProcessingIf</string>   
-            <key>Arguments</key>   
-            <dict>   
-                <key>predicate</key>   
+        <dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
                 <string>TRUEPREDICATE</string>
             </dict>
         </dict>


### PR DESCRIPTION
Since the processor has been part of the core since 1.1, it's a good time to switch over.

The only other reference to the shared processor in the AutoPkg org is due to be resolved here: https://github.com/autopkg/hansen-m-recipes/pull/156