### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/CLion/CLion.munki.recipe
+++ b/CLion/CLion.munki.recipe
@@ -30,7 +30,7 @@
         <true/>
     </dict>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.gregneagle.download.clion</string>

--- a/FoundationDB/FoundationDB.download.recipe
+++ b/FoundationDB/FoundationDB.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>Process</key>
 	<array>

--- a/FoundationDB/FoundationDB.munki.recipe
+++ b/FoundationDB/FoundationDB.munki.recipe
@@ -30,7 +30,7 @@
         <true/>
     </dict>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.gregneagle.download.FoundationDB</string>

--- a/FoundationDB/FoundationDB.pkg.recipe
+++ b/FoundationDB/FoundationDB.pkg.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.gregneagle.download.FoundationDB</string>

--- a/Zoom/ZoomRooms.munki.recipe
+++ b/Zoom/ZoomRooms.munki.recipe
@@ -32,7 +32,7 @@
             <true/>
         </dict>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.gregneagle.download.ZoomRooms</string>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.