### PR TITLE
Update cineSync recipes for cineSyncPlay and add ARCH input variable

### DIFF
--- a/cineSync/cineSync.download.recipe
+++ b/cineSync/cineSync.download.recipe
@@ -3,13 +3,20 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download recipe for cineSync client.</string>
+    <string>Download recipe for cineSync client.
+    
+Valid values for ARCH include:
+- "Intel" (default)
+- "Apple_Silicon"
+</string>
     <key>Identifier</key>
     <string>com.github.gregneagle.download.cineSync</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>cineSync</string>
+        <key>ARCH</key>
+        <string>Intel</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>
@@ -21,21 +28,21 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://cospective.com/download/</string>
+                <string>https://www.backlight.co/product/cinesync/download</string>
                 <key>re_pattern</key>
-                <string>a href="(?P&lt;download_url&gt;.+/cineSync.+\.dmg)"</string>
+                <string>a href="(?P&lt;download_url&gt;https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_%ARCH%_(?P&lt;version&gt;[\d\.]+).dmg)"</string>
             </dict>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
                 <string>%download_url%</string>
                 <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <string>%NAME%-%version%-%ARCH%.dmg</string>
             </dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -47,9 +54,9 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/cineSync.app</string>
+                <string>%pathname%/cineSyncPlay.app</string>
                 <key>requirement</key>
-                <string>identifier "com.risingsunresearch.cineSync" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = N3FUB9R6F9</string>
+                <string>identifier "com.ftrack.cinesyncplay" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = E3CFY5TPH3</string>
             </dict>
         </dict>
     </array>

--- a/cineSync/cineSync.install.recipe
+++ b/cineSync/cineSync.install.recipe
@@ -28,7 +28,7 @@
                 <array>
                     <dict>
                         <key>source_item</key>
-                        <string>cineSync.app</string>
+                        <string>cineSyncPlay.app</string>
                         <key>destination_path</key>
                         <string>/Applications/</string>
                     </dict>

--- a/cineSync/cineSync.munki.recipe
+++ b/cineSync/cineSync.munki.recipe
@@ -33,6 +33,8 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
@@ -40,8 +42,6 @@
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
         </dict>
     </array>
 </dict>

--- a/cineSync/cineSync.pkg.recipe
+++ b/cineSync/cineSync.pkg.recipe
@@ -17,65 +17,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>AppDmgVersioner</string>
+            <string>AppPkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>dmg_path</key>
-                <string>%pathname%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%pathname%/%app_name%</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/%app_name%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>id</key>
-                    <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
+                <key>app_path</key>
+                <string>%pathname%/cineSyncPlay.app</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Backlight has announced a major transition from cineSync 4 and legacy versions to cineSync 5, including a [new player called cineSync Play](https://www.backlight.co/blog/cinesync-5-the-next-generation-of-media-review-is-here#what-is-cinesync-play). This pull request updates the cineSync recipes to download cineSync Play 5.x, and adds support for specifying whether to download Intel or Apple Silicon architecture versions.

Verbose download/munki/pkg recipe run output with default Intel architecture:

```
% autopkg run -vvq cineSync/cineSync.{download,munki,pkg}.recipe
Processing cineSync/cineSync.download.recipe...
WARNING: cineSync/cineSync.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'a '
                         'href="(?P<download_url>https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_(?P<version>[\\d\\.]+).dmg)"',
           'url': 'https://www.backlight.co/product/cinesync/download'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (download_url): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg
URLTextSearcher: Found matching text (version): 5.4.4
URLTextSearcher: Found matching text (match): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg
{'Output': {'download_url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg',
            'match': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg',
            'version': '5.4.4'}}
URLDownloader
{'Input': {'filename': 'cineSync-5.4.4-Intel.dmg',
           'url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 13 Sep 2024 04:16:54 GMT
URLDownloader: Storing new ETag header: "6d11d4331d7d729cadfd1b4463042368"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Intel.dmg
{'Output': {'download_changed': True,
            'etag': '"6d11d4331d7d729cadfd1b4463042368"',
            'last_modified': 'Fri, 13 Sep 2024 04:16:54 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Intel.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Intel.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Intel.dmg/cineSyncPlay.app',
           'requirement': 'identifier "com.ftrack.cinesyncplay" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'E3CFY5TPH3'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Intel.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.A3vzDA/cineSyncPlay.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.A3vzDA/cineSyncPlay.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.A3vzDA/cineSyncPlay.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/receipts/cineSync.download-receipt-20241226-103751.plist
Processing cineSync/cineSync.munki.recipe...
WARNING: cineSync/cineSync.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'a '
                         'href="(?P<download_url>https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_(?P<version>[\\d\\.]+).dmg)"',
           'url': 'https://www.backlight.co/product/cinesync/download'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (download_url): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg
URLTextSearcher: Found matching text (version): 5.4.4
URLTextSearcher: Found matching text (match): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg
{'Output': {'download_url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg',
            'match': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg',
            'version': '5.4.4'}}
URLDownloader
{'Input': {'filename': 'cineSync-5.4.4-Intel.dmg',
           'url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 13 Sep 2024 04:16:54 GMT
URLDownloader: Storing new ETag header: "6d11d4331d7d729cadfd1b4463042368"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/downloads/cineSync-5.4.4-Intel.dmg
{'Output': {'download_changed': True,
            'etag': '"6d11d4331d7d729cadfd1b4463042368"',
            'last_modified': 'Fri, 13 Sep 2024 04:16:54 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/downloads/cineSync-5.4.4-Intel.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/downloads/cineSync-5.4.4-Intel.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/downloads/cineSync-5.4.4-Intel.dmg/cineSyncPlay.app',
           'requirement': 'identifier "com.ftrack.cinesyncplay" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'E3CFY5TPH3'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/downloads/cineSync-5.4.4-Intel.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.vBZ4uf/cineSyncPlay.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.vBZ4uf/cineSyncPlay.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.vBZ4uf/cineSyncPlay.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/downloads/cineSync-5.4.4-Intel.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'cineSync allows you to review video in '
                                      'sync, with anyone, anywhere in the '
                                      'world.',
                       'display_name': 'cineSync',
                       'name': 'cineSync',
                       'unattended_install': True},
           'repo_subdirectory': 'apps'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/cineSync-5.4.4.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/cineSync-5.4.4-Intel-5.4.4.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'cineSync',
                                                       'pkg_repo_path': 'apps/cineSync-5.4.4-Intel-5.4.4.dmg',
                                                       'pkginfo_path': 'apps/cineSync-5.4.4.plist',
                                                       'version': '5.4.4'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 26, 18, 38, 3),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'cineSync allows you to review video '
                                          'in sync, with anyone, anywhere in '
                                          'the world.',
                           'display_name': 'cineSync',
                           'installer_item_hash': '0e1964fa438945c8aadd6515fb33772b870126d7ba9602bac0245b4efcd14c83',
                           'installer_item_location': 'apps/cineSync-5.4.4-Intel-5.4.4.dmg',
                           'installer_item_size': 290345,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.ftrack.cinesyncplay',
                                         'CFBundleName': 'cineSyncPlay',
                                         'CFBundleShortVersionString': '5.4.4',
                                         'minosversion': '11',
                                         'path': '/Applications/cineSyncPlay.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'cineSyncPlay.app'}],
                           'minimum_os_version': '11',
                           'name': 'cineSync',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '5.4.4'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/cineSync-5.4.4-Intel-5.4.4.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/cineSync-5.4.4.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/receipts/cineSync.munki-receipt-20241226-103803.plist
Processing cineSync/cineSync.pkg.recipe...
WARNING: cineSync/cineSync.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'a '
                         'href="(?P<download_url>https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_(?P<version>[\\d\\.]+).dmg)"',
           'url': 'https://www.backlight.co/product/cinesync/download'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (download_url): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg
URLTextSearcher: Found matching text (version): 5.4.4
URLTextSearcher: Found matching text (match): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg
{'Output': {'download_url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg',
            'match': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg',
            'version': '5.4.4'}}
URLDownloader
{'Input': {'filename': 'cineSync-5.4.4-Intel.dmg',
           'url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Intel_5.4.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 13 Sep 2024 04:16:54 GMT
URLDownloader: Storing new ETag header: "6d11d4331d7d729cadfd1b4463042368"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg
{'Output': {'download_changed': True,
            'etag': '"6d11d4331d7d729cadfd1b4463042368"',
            'last_modified': 'Fri, 13 Sep 2024 04:16:54 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg/cineSyncPlay.app',
           'requirement': 'identifier "com.ftrack.cinesyncplay" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'E3CFY5TPH3'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Oan2u9/cineSyncPlay.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Oan2u9/cineSyncPlay.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Oan2u9/cineSyncPlay.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg/cineSyncPlay.app',
           'version': '5.4.4'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg
AppPkgCreator: BundleID: com.ftrack.cinesyncplay
AppPkgCreator: Copied /private/tmp/dmg.z6TbPo/cineSyncPlay.app to ~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/payload/Applications/cineSyncPlay.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.ftrack.cinesyncplay',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/cineSyncPlay-5.4.4.pkg',
                                                        'version': '5.4.4'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '5.4.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/receipts/cineSync.pkg-receipt-20241226-103847.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Intel.dmg
    ~/Library/AutoPkg/Cache/com.github.gregneagle.munki.cineSync/downloads/cineSync-5.4.4-Intel.dmg
    ~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/downloads/cineSync-5.4.4-Intel.dmg

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path               Pkg Repo Path                        Icon Repo Path
    ----      -------  --------  ------------               -------------                        --------------
    cineSync  5.4.4    testing   apps/cineSync-5.4.4.plist  apps/cineSync-5.4.4-Intel-5.4.4.dmg

The following packages were built:
    Identifier               Version  Pkg Path
    ----------               -------  --------
    com.ftrack.cinesyncplay  5.4.4    ~/Library/AutoPkg/Cache/com.github.gregneagle.pkg.cineSync/cineSyncPlay-5.4.4.pkg
```

Verbose download recipe run output with Apple Silicon architecture specified:

```
% autopkg run -vvq cineSync/cineSync.download.recipe -k ARCH=Apple_Silicon
Processing cineSync/cineSync.download.recipe...
WARNING: cineSync/cineSync.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'a '
                         'href="(?P<download_url>https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Apple_Silicon_(?P<version>[\\d\\.]+).dmg)"',
           'url': 'https://www.backlight.co/product/cinesync/download'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (download_url): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Apple_Silicon_5.4.4.dmg
URLTextSearcher: Found matching text (version): 5.4.4
URLTextSearcher: Found matching text (match): https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Apple_Silicon_5.4.4.dmg
{'Output': {'download_url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Apple_Silicon_5.4.4.dmg',
            'match': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Apple_Silicon_5.4.4.dmg',
            'version': '5.4.4'}}
URLDownloader
{'Input': {'filename': 'cineSync-5.4.4-Apple_Silicon.dmg',
           'url': 'https://download.ftrack.com/cineSyncPlay/cineSyncPlay_macOS_Apple_Silicon_5.4.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 13 Sep 2024 04:16:54 GMT
URLDownloader: Storing new ETag header: "388444ff6c64739854286c20c097b223"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Apple_Silicon.dmg
{'Output': {'download_changed': True,
            'etag': '"388444ff6c64739854286c20c097b223"',
            'last_modified': 'Fri, 13 Sep 2024 04:16:54 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Apple_Silicon.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Apple_Silicon.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Apple_Silicon.dmg/cineSyncPlay.app',
           'requirement': 'identifier "com.ftrack.cinesyncplay" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'E3CFY5TPH3'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Apple_Silicon.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.LHykVj/cineSyncPlay.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.LHykVj/cineSyncPlay.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.LHykVj/cineSyncPlay.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/receipts/cineSync.download-receipt-20241226-103928.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gregneagle.download.cineSync/downloads/cineSync-5.4.4-Apple_Silicon.dmg
```
