### PR TITLE
Add RELEASE_CHANNEL for Claude Code dynamic download URL

### DIFF
--- a/ClaudeCode/ClaudeCode.download.recipe
+++ b/ClaudeCode/ClaudeCode.download.recipe
@@ -5,7 +5,8 @@
 	<key>Description</key>
 	<string>Downloads latest version of Claude Code command-line tool.
 Set DOWNLOAD_ARCH to "x64" for Intel, "arm64" for Apple silicon.
-Based on the script at https://claude.ai/install.sh</string>
+Based on the script at https://claude.ai/install.sh
+RELEASE_CHANNEL may be either "latest" or "stable"</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.gregneagle-recipes.claude-code.download</string>
 	<key>Input</key>
@@ -14,6 +15,8 @@ Based on the script at https://claude.ai/install.sh</string>
 		<string>ClaudeCode</string>
 		<key>DOWNLOAD_ARCH</key>
 		<string>arm64</string>
+		<key>RELEASE_CHANNEL</key>
+		<string>latest</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0</string>
@@ -25,7 +28,7 @@ Based on the script at https://claude.ai/install.sh</string>
 				<key>re_pattern</key>
 				<string>.*</string>
 				<key>url</key>
-				<string>https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/latest</string>
+				<string>https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/%RELEASE_CHANNEL%</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 			</dict>


### PR DESCRIPTION
Updated the recipe to include a RELEASE_CHANNEL key to allow admins to choose stable branch.