### PR TITLE
Update ClaudeCode.download.recipe

### DIFF
--- a/ClaudeCode/ClaudeCode.download.recipe
+++ b/ClaudeCode/ClaudeCode.download.recipe
@@ -45,6 +45,10 @@ RELEASE_CHANNEL may be either "latest" or "stable"</string>
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>


### PR DESCRIPTION
Adds missing `EndOfCheckPhase` processor so the recipe can be used with tools like cloud-autopkg-runner.